### PR TITLE
chore(dependencies): update dependencies to the latest release and minor refactoring

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="Your App"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.7.0"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -63,7 +63,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -99,28 +99,35 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.7.0"
   native_updater:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.1.1"
   package_info:
     dependency: transitive
     description:
@@ -134,7 +141,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -153,7 +160,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -188,7 +195,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.1"
+    version: "0.4.9"
   typed_data:
     dependency: transitive
     description:
@@ -202,7 +209,21 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.6"
+    version: "6.1.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.17"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.16"
   url_launcher_linux:
     dependency: transitive
     description:
@@ -244,7 +265,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
+  flutter: ">=2.8.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -64,6 +64,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -79,6 +86,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.13.4"
   http_parser:
     dependency: transitive
     description:
@@ -92,7 +106,7 @@ packages:
       name: in_app_update
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   js:
     dependency: transitive
     description:
@@ -128,13 +142,48 @@ packages:
       relative: true
     source: path
     version: "0.1.1"
-  package_info:
+  package_info_plus:
     dependency: transitive
     description:
-      name: package_info
+      name: package_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "1.4.2"
+  package_info_plus_linux:
+    dependency: transitive
+    description:
+      name: package_info_plus_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.5"
+  package_info_plus_macos:
+    dependency: transitive
+    description:
+      name: package_info_plus_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.2"
+  package_info_plus_web:
+    dependency: transitive
+    description:
+      name: package_info_plus_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.5"
+  package_info_plus_windows:
+    dependency: transitive
+    description:
+      name: package_info_plus_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.5"
   path:
     dependency: transitive
     description:
@@ -266,6 +315,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.2"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.5.2"
 sdks:
   dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=2.8.0"

--- a/lib/src/native_updater.dart
+++ b/lib/src/native_updater.dart
@@ -4,7 +4,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:in_app_update/in_app_update.dart';
-import 'package:package_info/package_info.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 import 'error_material_alert.dart';
 import 'update_cupertino_alert.dart';
@@ -59,11 +59,14 @@ class NativeUpdater {
     _nativeUpdaterInstance._iOSCloseButtonLabel = iOSCloseButtonLabel;
     _nativeUpdaterInstance._iOSIgnoreButtonLabel = iOSIgnoreButtonLabel;
     _nativeUpdaterInstance._iOSAlertTitle = iOSAlertTitle;
-    _nativeUpdaterInstance._requireUpdateText = requireUpdateText ?? 'requires that you update to the latest version. You cannot use this app until it is updated.';
-    _nativeUpdaterInstance._recommendUpdateText = recommendUpdateText ?? 'recommends that you update to the latest version. You can keep using this app while downloading the update.';
+    _nativeUpdaterInstance._requireUpdateText = requireUpdateText ??
+        'requires that you update to the latest version. You cannot use this app until it is updated.';
+    _nativeUpdaterInstance._recommendUpdateText = recommendUpdateText ??
+        'recommends that you update to the latest version. You can keep using this app while downloading the update.';
     _nativeUpdaterInstance._errorText = errorText;
     _nativeUpdaterInstance._errorCloseButtonLabel = errorCloseButtonLabel;
     _nativeUpdaterInstance._errorSubtitle = errorSubtitle;
+
     /// Show the alert based on current platform
     if (Platform.isIOS) {
       _nativeUpdaterInstance._showCupertinoAlertDialog();
@@ -77,11 +80,9 @@ class NativeUpdater {
     String selectedDefaultDescription;
 
     if (_forceUpdate) {
-      selectedDefaultDescription =
-          '$_appName $_requireUpdateText';
+      selectedDefaultDescription = '$_appName $_requireUpdateText';
     } else {
-      selectedDefaultDescription =
-          '$_appName $_recommendUpdateText';
+      selectedDefaultDescription = '$_appName $_recommendUpdateText';
     }
 
     Widget alert = UpdateCupertinoAlert(
@@ -109,13 +110,24 @@ class NativeUpdater {
     try {
       AppUpdateInfo _updateInfo = await InAppUpdate.checkForUpdate();
 
-      if (_updateInfo.updateAvailability == UpdateAvailability.updateAvailable) {
+      if (_updateInfo.updateAvailability ==
+          UpdateAvailability.updateAvailable) {
         if (_forceUpdate == true) {
-          InAppUpdate.performImmediateUpdate()
-              .catchError((e) => developer.log(e.toString()));
+          InAppUpdate.performImmediateUpdate().catchError(
+            (Object e) {
+              developer.log(
+                e.toString(),
+              );
+            },
+          );
         } else if (_forceUpdate == false) {
-          InAppUpdate.startFlexibleUpdate()
-              .catchError((e) => developer.log(e.toString()));
+          InAppUpdate.startFlexibleUpdate().catchError(
+            (Object e) {
+              developer.log(
+                e.toString(),
+              );
+            },
+          );
         }
       }
     } on PlatformException catch (e) {
@@ -126,9 +138,9 @@ class NativeUpdater {
         builder: (BuildContext context) {
           return ErrorMaterialAlert(
             appName: _appName,
-            description:
-                _errorText ?? 'This version of $_appName was not installed from Google Play Store.',
-            errorCloseButtonLabel:_errorCloseButtonLabel,
+            description: _errorText ??
+                'This version of $_appName was not installed from Google Play Store.',
+            errorCloseButtonLabel: _errorCloseButtonLabel,
             errorSubtitle: _errorSubtitle,
           );
         },

--- a/lib/src/update_cupertino_alert.dart
+++ b/lib/src/update_cupertino_alert.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class UpdateCupertinoAlert extends StatelessWidget {
@@ -40,7 +39,7 @@ class UpdateCupertinoAlert extends StatelessWidget {
 
     Widget updateButton = CupertinoDialogAction(
       child: Text(updateButtonLabel),
-      onPressed: () => launch(appStoreUrl),
+      onPressed: () => launchUrl(Uri.parse(appStoreUrl)),
     );
 
     return CupertinoAlertDialog(

--- a/lib/src/update_material_alert.dart
+++ b/lib/src/update_material_alert.dart
@@ -14,17 +14,16 @@ class UpdateMaterialAlert extends StatelessWidget {
   final String ignoreButtonLabel;
   final String newVersionLabel;
 
-  UpdateMaterialAlert({
-    required this.forceUpdate,
-    required this.appName,
-    required this.playStoreUrl,
-    required this.titlePrefix,
-    required this.description,
-    required this.updateButtonLabel,
-    required this.closeButtonLabel,
-    required this.ignoreButtonLabel,
-    this.newVersionLabel = 'New version available'
-  });
+  UpdateMaterialAlert(
+      {required this.forceUpdate,
+      required this.appName,
+      required this.playStoreUrl,
+      required this.titlePrefix,
+      required this.description,
+      required this.updateButtonLabel,
+      required this.closeButtonLabel,
+      required this.ignoreButtonLabel,
+      this.newVersionLabel = 'New version available'});
 
   @override
   Widget build(BuildContext context) {
@@ -47,7 +46,7 @@ class UpdateMaterialAlert extends StatelessWidget {
       child: Text(updateButtonLabel.toUpperCase(),
           style: TextStyle(color: Colors.white)),
       style: flatButtonStyle,
-      onPressed: () => launch(playStoreUrl),
+      onPressed: () => launchUrl(Uri.parse(playStoreUrl)),
     );
 
     return AlertDialog(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -42,14 +42,14 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -78,21 +78,28 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   package_info:
     dependency: "direct main"
     description:
@@ -106,7 +113,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -125,7 +132,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -160,14 +167,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.9"
   url_launcher:
     dependency: "direct main"
     description:
@@ -216,7 +216,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=2.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -50,6 +50,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -65,13 +72,27 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.13.4"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.0"
   in_app_update:
     dependency: "direct main"
     description:
       name: in_app_update
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   js:
     dependency: transitive
     description:
@@ -100,13 +121,48 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.7.0"
-  package_info:
+  package_info_plus:
     dependency: "direct main"
     description:
-      name: package_info
+      name: package_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "1.4.2"
+  package_info_plus_linux:
+    dependency: transitive
+    description:
+      name: package_info_plus_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.5"
+  package_info_plus_macos:
+    dependency: transitive
+    description:
+      name: package_info_plus_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.2"
+  package_info_plus_web:
+    dependency: transitive
+    description:
+      name: package_info_plus_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.5"
+  package_info_plus_windows:
+    dependency: transitive
+    description:
+      name: package_info_plus_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.5"
   path:
     dependency: transitive
     description:
@@ -168,13 +224,34 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.9"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.1"
   url_launcher:
     dependency: "direct main"
     description:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.10"
+    version: "6.1.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.17"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.16"
   url_launcher_linux:
     dependency: transitive
     description:
@@ -217,6 +294,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.2"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.5.2"
 sdks:
   dart: ">=2.17.0-0 <3.0.0"
-  flutter: ">=2.0.0"
+  flutter: ">=2.8.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.1.2
 homepage: https://github.com/ofload/native_updater
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,7 @@
 name: native_updater
 description: Flutter package for prompting users to update with a native dialog whether using the app store version or any version at the user's discretion.
-author: Ofload <tech@ofload.com>
 
-version: 0.1.1
+version: 0.1.2
 homepage: https://github.com/ofload/native_updater
 
 environment:
@@ -12,11 +11,11 @@ dependencies:
   flutter:
     sdk: flutter
   # package_info will help us to find current installed version of application.
-  package_info: ^2.0.2
+  package_info_plus: ^1.4.2
   # url_launcher will help us to trigger app store / play store url from our app.
-  url_launcher: ^6.0.10
+  url_launcher: ^6.1.2
   # Enables In App Updates on Android using the official Android APIs.
-  in_app_update: ^2.0.0
+  in_app_update: ^3.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

- Remove deprecated Flutter Android v2 Embedding usages, including in example app
- Update a dependency to the latest release. (package_info_plus, url_launcher, in_app_update)
- Bump Dart SDK version from 2.12.0 to 2.17.0
- Refactor update_cupertino_alert.dart and update_material_alert.dart to use launchUrl method instead of launch method since the launch method in url_launcher plugin is depreacted

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [x] ✅ Build configuration change
- [x] 📝 Documentation
- [x] 🗑️ Chore